### PR TITLE
Force AssemblyResolver to find symbols from assemblies using exact ma…

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -86,6 +86,7 @@ namespace Confuser.Core {
 			bool ok = false;
 			try {
 				var asmResolver = new AssemblyResolver();
+				asmResolver.FindExactMatch = true;
 				asmResolver.EnableTypeDefCache = true;
 				asmResolver.DefaultModuleContext = new ModuleContext(asmResolver);
 				context.Resolver = asmResolver;


### PR DESCRIPTION
…tches. This setting precedes EnableFrameworkRedirect. This patch allows an assembly to target symbols that exist in multiple versions of another assembly, without crashing ConfuserEx.