### PR TITLE
Fixed Caliburn Multi-View Detection

### DIFF
--- a/Confuser.Renamer/Analyzers/CaliburnAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/CaliburnAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Confuser.Renamer.Analyzers {
 				}
 
 				// Test for Multi-view
-				string multiViewNs = type.Namespace + "." + type.Name.Replace("ViewModel", "");
+				string multiViewNs = viewNs + "." + type.Name.Replace("ViewModel", "");
 				foreach (var t in type.Module.Types)
 					if (t.Namespace == multiViewNs) {
 						service.SetCanRename(type, false);


### PR DESCRIPTION
Fixed typo caused multi-view detection to check the wrong namespace.